### PR TITLE
Fix failing nightwatch test, code cleaning.

### DIFF
--- a/src/www/chat.js
+++ b/src/www/chat.js
@@ -1,36 +1,32 @@
 /* connect to the example chat data file*/
 
 var username = {
+	// check to see if the username exists
 	exists: function () {
 		return Boolean(localStorage.username);
 	},
 
+	// build a username
 	generate: function () {
 		localStorage.username = Gun.text.random(6);
 		return localStorage.username;
 	},
 
+	// return a username
 	get: function () {
-		// var noUsername = !username.exists();
-
-console.log('@@@@@@@@@@ username.get');
 
 		if (!username.exists()) {
-console.log('@@@@@@@@@@ no username - gonna generate one');
 			var alias = username.generate();
 			localStorage.username = alias;
 		}
 
-console.log('@@@@@@@@@@ returning localStorage.username:', localStorage.username);
-return false;
 		return localStorage.username;
 	}
 
 };
 
-(function() {
-	$('#who').val(username.get());
-})();
+// set the username as the input value
+$('#who').val(username.get());
 
 
 

--- a/test/nightwatch/chat.spec.js
+++ b/test/nightwatch/chat.spec.js
@@ -8,10 +8,10 @@ module.exports = {
 
 	'Serve the index.html page': function (browser) {
 		// TODO: universalize the port number
-		browser.url('http://localhost:4242')  
+		browser.url('http://localhost:4242')
 			.waitForElementVisible('body', 500);
 
-		browser.getTitle(function (title) {
+		browser.getTitle( function (title) {
 			expect(title).to.match(/gun/i);
 		});
 
@@ -45,17 +45,20 @@ module.exports = {
 		browser.url('http://localhost:4242')
 			.waitForElementVisible('body', 500);
 
-		browser.execute( function () {
-			localStorage.username = username.value;
-		});
+		browser.execute( function (value) {
+			localStorage.username = value;
+		}, [username.value]);
 
 		browser.refresh( function () {
-			browser.expect.element(username.element).to.be.present;
-  browser.pause(1000);
-			browser.expect.element(username.element).value.to.equal(username.value);
-			browser.expect.element(username.element).not.to.be.present;
+			browser.expect.element(username.element)
+				.to.be.present;
+
+			browser.expect.element(username.element)
+				.value.to.equal(username.value);
+
+
 			browser.end();
-		})
+		});
 
 	}
 };
@@ -90,5 +93,3 @@ module.exports = {
 //      });
 //   });
 // };
-
-


### PR DESCRIPTION
There were a few issues in the third nightwatch test that have been resolved. For one, we were trying to access a local scope node variable on the client through `browser.execute`.  That's been fixed by passing an argument through the second parameter (see API docs). There was another statement that was contradictive (I believe intentionally) that both expected an element to be visible and not to be visible simultaniously.
In chat.js, the username.get() function was prematurely returning false as the value every time, causing the username to always be "false" and failing the tests.
Removed some troubleshooting comments and cleaned up some code. Yay!
