### PR TITLE
Change event handler, isolate username logic, clean and dry code, pass all tests.

### DIFF
--- a/nightwatch.json
+++ b/nightwatch.json
@@ -20,7 +20,7 @@
 
   "test_settings" : {
     "default" : {
-      "launch_url" : "http://localhost",
+      "launch_url" : "http://localhost:4242/index.html",
       "selenium_port"  : 4444,
       "selenium_host"  : "localhost",
       "silent": true,

--- a/src/www/chat.js
+++ b/src/www/chat.js
@@ -1,43 +1,13 @@
+/*globals $, Gun, username*/
 /* connect to the example chat data file*/
 
-var username = {
-	// check to see if the username exists
-	exists: function () {
-		return Boolean(localStorage.username);
-	},
-
-	// build a username
-	generate: function () {
-		localStorage.username = Gun.text.random(6);
-		return localStorage.username;
-	},
-
-	// return a username
-	get: function () {
-
-		if (!username.exists()) {
-			var alias = username.generate();
-			localStorage.username = alias;
-		}
-
-		return localStorage.username;
-	},
-
-	// edit a username
-	save: function(newName) {
-		localStorage.username = newName;
-		return localStorage.username;
-	}
-
-};
-
 // set the username as the input value
-$('#who').val(username.get());
+username.input.val(username.get());
 
-// when a user enters then exits the alias field, 
+// when a user enters then exits the alias field,
 // the field's value is saved as their username
-$( "#who" ).blur(function() {
-  username.save($( "#who" )[0].value);
+username.input.on('change', function () {
+	username.save(this.value);
 });
 
 

--- a/src/www/index.html
+++ b/src/www/index.html
@@ -35,6 +35,7 @@
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
   <script src="colorize.js"></script>
   <!-- script src="node_modules/marked/lib/marked.js"></script -->
+  <script src="username.js"></script>
   <script src="chat.js"></script>
 
 </body>

--- a/src/www/username.js
+++ b/src/www/username.js
@@ -1,0 +1,44 @@
+/*global Gun, $*/
+
+var username;
+
+(function () {
+	'use strict';
+
+	username = {
+
+		// check to see if the username exists
+		exists: function () {
+			return Boolean(localStorage.username);
+		},
+
+		// build a username
+		generate: function () {
+			localStorage.username = Gun.text.random(6);
+			return localStorage.username;
+		},
+
+		// return a username
+		get: function () {
+
+			if (!username.exists()) {
+				var alias = username.generate();
+				localStorage.username = alias;
+			}
+
+			return localStorage.username;
+		},
+
+		// edit a username
+		save: function (newName) {
+			localStorage.username = newName;
+			return localStorage.username;
+		}
+
+	};
+
+	if (typeof $ === 'function') {
+		username.input = $('#who');
+	}
+
+}());

--- a/test/index.html
+++ b/test/index.html
@@ -5,7 +5,7 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<link rel="stylesheet" href="mocha.css" />
-		<script type="text/javascript" src="../src/www/chat.js"></script>
+		<script type="text/javascript" src="../src/www/username.js"></script>
 	</head>
 	<body>
 		<div id="mocha"></div>

--- a/test/nightwatch/chat.spec.js
+++ b/test/nightwatch/chat.spec.js
@@ -4,6 +4,10 @@
 // use chai's expect().to.be library
 var expect = require('chai').expect;
 
+var username = {
+	input: '#who'
+};
+
 module.exports = {
 
 	'Serve the index.html page': function (browser) {
@@ -11,7 +15,7 @@ module.exports = {
 		browser.url('http://localhost:4242')
 			.waitForElementVisible('body', 500);
 
-		browser.getTitle( function (title) {
+		browser.getTitle(function (title) {
 			expect(title).to.match(/gun/i);
 		});
 
@@ -19,71 +23,80 @@ module.exports = {
 	},
 
 	'Get the user id - no username exists in localStorage': function (browser) {
-		var username = '#who';
 
 		browser.url('http://localhost:4242')
 			.waitForElementVisible('body', 500);
 
-		browser.execute( function () {
+		browser.execute(function () {
 			localStorage.clear();
 			console.log('Yo!'); // TODO: override browser execute console.log
 		});
 
-		browser.refresh( function () {
-			browser.expect.element(username).to.be.present;
-			browser.expect.element(username).value.to.match(/\S/);
+		browser.refresh(function () {
+			browser.expect.element(username.input).to.be.present;
+			browser.expect.element(username.input).value.to.match(/\S/);
 			browser.end();
 		});
 	},
 
 	'Get the user id - username does exist in localStorage': function (browser) {
-		var username = {
-			element: '#who',
-			value: 'the Most Awesome Nighthawk (aka the MAN)'
-		};
+		username.value = 'the Most Awesome Nighthawk (aka the MAN)';
 
 		browser.url('http://localhost:4242')
 			.waitForElementVisible('body', 500);
 
-		browser.execute( function (value) {
+		browser.execute(function (value) {
 			localStorage.username = value;
 		}, [username.value]);
 
-		browser.refresh( function () {
-			browser.expect.element(username.element).to.be.present;
-			browser.expect.element(username.element).value.to.equal(username.value);
+		browser.refresh(function () {
+			browser.expect.element(username.input)
+				.to.be.present;
+
+			browser.expect.element(username.input).value
+				.to.equal(username.value);
+
 			browser.end();
 		});
 	},
 
 	'User edits to the username persist': function (browser) {
-		var username = {
-			element: '#who',
-			value: 'Ned the Nighthawk'
-		};
+		username.value = 'Ned the Nighthawk';
 
-		browser.url('http://localhost:4242')
-			.waitForElementVisible('body', 500);
+		browser.url('http://localhost:4242');
 
 		// should initially be set to a random value
 		browser
-		.execute( function (value) {
-			localStorage.clear();
-		})
-		.refresh( function () {
-			browser.expect.element(username.element).to.be.present;
-			browser.expect.element(username.element).value.to.match(/\S/);
-			browser.expect.element(username.element).value.not.to.equal(username.value);
-		})
-		// simulate user modifying their username
-    .click('input[id=who]')
-		.setValue('input[id=who]', 'Ned the Nighthawk')
-		// should now be set to user's edited value
-		.refresh( function () {
-			browser.expect.element(username.element).to.be.present;
-			browser.expect.element(username.element).value.to.equal(username.value);
-			browser.end();
-		});
+			.execute(function () {
+				localStorage.clear();
+			})
+			.refresh(function () {
+				browser.waitForElementVisible('input', 500);
+
+				browser.expect.element(username.input)
+					.to.be.present;
+
+				browser.expect.element(username.input).value
+					.to.match(/\S/);
+
+				browser.expect.element(username.input).value
+					.not.to.equal(username.value);
+
+				// simulate user modifying their username
+				browser
+					.clearValue(username.input)
+					.setValue(username.input, username.value);
+
+			})
+			.refresh(function () {
+				// should now be set to user's edited value
+				browser.waitForElementVisible(username.input, 500);
+
+				browser.expect.element(username.input).value
+					.to.equal(username.value);
+
+				browser.end();
+			});
 	}
 };
 

--- a/test/nightwatch/username.spec.js
+++ b/test/nightwatch/username.spec.js
@@ -1,9 +1,6 @@
 /*jslint node: true */
 'use strict';
 
-// use chai's expect().to.be library
-var expect = require('chai').expect;
-
 var username = {
 	input: '#who'
 };
@@ -12,22 +9,17 @@ module.exports = {
 
 	'Serve the index.html page': function (browser) {
 		// TODO: universalize the port number
-		browser.url('http://localhost:4242')
-			.waitForElementVisible('body', 500);
+		browser.init().waitForElementPresent('body', 500);
 
-		browser.getTitle(function (title) {
-			expect(title).to.match(/gun/i);
-		});
+		browser.assert.urlContains("index.html");
+		browser.expect.element(username.input).to.be.present;
 
 		browser.end();
 	},
 
 	'Get the user id - no username exists in localStorage': function (browser) {
 
-		browser.url('http://localhost:4242')
-			.waitForElementVisible('body', 500);
-
-		browser.execute(function () {
+		browser.init().execute(function () {
 			localStorage.clear();
 			console.log('Yo!'); // TODO: override browser execute console.log
 		});
@@ -42,8 +34,7 @@ module.exports = {
 	'Get the user id - username does exist in localStorage': function (browser) {
 		username.value = 'the Most Awesome Nighthawk (aka the MAN)';
 
-		browser.url('http://localhost:4242')
-			.waitForElementVisible('body', 500);
+		browser.init().waitForElementVisible('body', 500);
 
 		browser.execute(function (value) {
 			localStorage.username = value;
@@ -63,15 +54,12 @@ module.exports = {
 	'User edits to the username persist': function (browser) {
 		username.value = 'Ned the Nighthawk';
 
-		browser.url('http://localhost:4242');
-
-		// should initially be set to a random value
-		browser
+		browser.init()
 			.execute(function () {
 				localStorage.clear();
 			})
 			.refresh(function () {
-				browser.waitForElementVisible('input', 500);
+				browser.waitForElementVisible(username.input, 500);
 
 				browser.expect.element(username.input)
 					.to.be.present;


### PR DESCRIPTION
The blur event is only triggered when focus is taken from the element, and since the e2e tests weren't moving the mouse away, the username was never persisted. Now, the change event is used instead, allowing the tests to progress further. The tests also seemed to be concatenating the input value, rather than replacing it. They now start by clearing the value first.

Since jQuery isn't used by mocha, it was throwing a nasty error. For the modularity of the code and reliability of the tests, all username logic has been moved into the username.js file inside www/.

Nightwatch's tests were repetitive with the username logic. The selector has been bumped up to a parent scope to reduce repetition.
The code is also beautified a bit.

Mocha and Nightwatch tests are passing.
